### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ sentencepiece==0.2.0
 gradio==5.22.0
 
 --extra-index-url https://download.pytorch.org/whl/cu124
-torch==2.4.0
+torch==2.6.0
 torchvision==0.19.0


### PR DESCRIPTION
requirements.txt is still trying to install torch==2.4.0, but that version doesn't exist for platform (Python 3.13 on macOS ARM64). Only 2.6.0 is available.